### PR TITLE
Support non-xml responses

### DIFF
--- a/lib/freshbooks.rb
+++ b/lib/freshbooks.rb
@@ -67,11 +67,11 @@ module FreshBooks
                                :headers => auth,
                                :body => Client.xml_body(method, params))
 
-      if resp.class == Hash
+      if resp['response'].class == Hash
         return Response.new resp
       end
 
-      resp
+      resp['response']
     end
 
     # takes nested Hash/Array combos and generates isomorphic

--- a/lib/freshbooks.rb
+++ b/lib/freshbooks.rb
@@ -63,9 +63,15 @@ module FreshBooks
     # note: we only need to provide a #post method because the
     # FreshBooks API is POST only
     def post(method, params={}) # :nodoc:
-      Response.new Client.post(api_url,
+      resp = Client.post(api_url,
                                :headers => auth,
                                :body => Client.xml_body(method, params))
+
+      if resp.class == Hash
+        return Response.new resp
+      end
+
+      resp
     end
 
     # takes nested Hash/Array combos and generates isomorphic

--- a/lib/freshbooks.rb
+++ b/lib/freshbooks.rb
@@ -71,7 +71,7 @@ module FreshBooks
         return Response.new resp
       end
 
-      resp['response']
+      resp.bytes
     end
 
     # takes nested Hash/Array combos and generates isomorphic


### PR DESCRIPTION
Wanted to use invoice.getPDF but code is assuming every response will be XML/hash.
